### PR TITLE
feat: enhance monitoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,10 @@ COPY --from=builder $PROJECT_ROOT_PATH $PROJECT_ROOT_PATH
 COPY src/ $PROJECT_ROOT_PATH/src
 COPY main.py $PROJECT_ROOT_PATH/main.py
 
+# Copy the entrypoint script from local project root onto the container
+COPY docker_entrypoint.sh $PROJECT_ROOT_PATH/docker_entrypoint.sh
+RUN chmod +x $PROJECT_ROOT_PATH/docker_entrypoint.sh
+
 WORKDIR $PROJECT_ROOT_PATH
-# Use the python interpreter and packages from the virtual environment directly (without poetry run)
-CMD [".venv/bin/python3", "main.py"]
+# The entrypoint script adds timeout logic for the python process
+ENTRYPOINT ["./docker_entrypoint.sh"]

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -eu
+
+# Default to 45 min (2,700 s) if not overridden
+TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-2700}"
+
+echo "Running main.py with a ${TIMEOUT_SECONDS}s timeout"
+# Use the python interpreter and packages from the virtual environment directly (without poetry run)
+timeout --foreground "${TIMEOUT_SECONDS}s" .venv/bin/python3 main.py
+STATUS=$?
+
+# Direct to stderr if the process was killed by timeout
+if [ "$STATUS" -eq 124 ]; then
+    echo "[ERROR] Python process timed out after ${TIMEOUT_SECONDS} seconds" >&2
+# Otherwise, propagate the exit code from the Python process
+elif [ "$STATUS" -ne 0 ]; then
+    echo "[ERROR] Python exited with status ${STATUS}" >&2
+fi
+
+exit "$STATUS"

--- a/main.py
+++ b/main.py
@@ -1,63 +1,41 @@
 import os
-from concurrent.futures import (
-    Future,
-    ProcessPoolExecutor,
-)
-from concurrent.futures import (
-    TimeoutError as FutureTimeout,
-)
+import sys
 from datetime import datetime
 
-import pandas as pd
-
 from src.api import query_etf_data
-from src.utils import exit_on_error, setup_logger, write_to_s3
-
-logger = setup_logger(name="ETF KPIs Scraper")
+from src.utils import catch_errors, setup_logger, write_to_s3
 
 
-@exit_on_error(logger=logger)
+@catch_errors
 def main() -> int:
+    logger = setup_logger(name="ETF KPIs Scraper")
     ENV = os.getenv("ENV", "dev")
     logger.info(f"Running the task in {ENV} mode")
 
-    # If in 'dev' mode, specify a smaller number of etfs to query for testing purposes and a shorter timeout
+    # If in 'dev' mode, specify a smaller number of etfs to query for testing purposes
     if ENV == "dev":
         max_etfs = 20
-        timeout_seconds = 60 * 5
     elif ENV == "prod":
         max_etfs = int(os.getenv("MAX_ETFS", "1"))
-        timeout_seconds = 60 * 45
     ipo_date = datetime.strptime(
         os.getenv("IPO_DATE", datetime.today().strftime("%Y-%m-%d")), "%Y-%m-%d"
     )
+    etfs_data = query_etf_data(logger=logger, max_etfs=max_etfs, ipo_date=ipo_date)
 
-    logger.info(f"Submitting ETF query task (timeout {timeout_seconds}s)…")
-    # Run query_etf_data in a separate process to enforce hard timeout
-    with ProcessPoolExecutor(max_workers=1) as executor:
-        future: Future[pd.DataFrame] = executor.submit(
-            query_etf_data, logger, max_etfs, ipo_date
-        )
-        try:
-            etfs_data = future.result(timeout=timeout_seconds)
-        except FutureTimeout:
-            logger.error(f"[ERROR] ETF query exceeded {timeout_seconds}s")
-            # Raise to be caught by decorator
-            raise
+    s3_bucket = os.getenv("S3_BUCKET")
+    if not s3_bucket:
+        logger.error("[ERROR] The S3_BUCKET environment variable is not set")
+        return 1
+    parquet = os.getenv("PARQUET") == "True"
+    s3_path = (
+        f"s3://{s3_bucket}/daily-kpis/etf_kpis_{datetime.today().strftime('%Y_%m_%d')}"
+    )
+    logger.info("Writing scraper data to s3")
+    write_to_s3(data=etfs_data, s3_path=s3_path, parquet=parquet)
+    logger.info(f"[SUCCESS] Successfully written data to s3")
 
-        s3_bucket = os.getenv("S3_BUCKET")
-        if not s3_bucket:
-            logger.error("[ERROR] S3_BUCKET environment variable is not set")
-            raise RuntimeError("The S3_BUCKET environment variable is required")
-
-        parquet = os.getenv("PARQUET") == "True"
-        s3_path = f"s3://{s3_bucket}/daily-kpis/etf_kpis_{datetime.today().strftime('%Y_%m_%d')}"
-        logger.info("Writing scraper data to s3")
-        write_to_s3(data=etfs_data, s3_path=s3_path, parquet=parquet)
-        logger.info(f"[SUCCESS] Successfully written data to s3")
-
-        return 0
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/terraform/monitoring/outputs.tf
+++ b/terraform/monitoring/outputs.tf
@@ -1,11 +1,11 @@
 output "success_sns_topic_arn" {
   description = "ARN of the SNS topic for task success notifications"
-  value       = aws_sns_topic.task_success.arn
+  value       = aws_sns_topic.success.arn
 }
 
 output "failure_sns_topic_arn" {
   description = "ARN of the SNS topic for task failure notifications"
-  value       = aws_sns_topic.task_failure.arn
+  value       = aws_sns_topic.failure.arn
 }
 
 output "chatbot_config_arn" {

--- a/terraform/monitoring/variables.tf
+++ b/terraform/monitoring/variables.tf
@@ -123,8 +123,8 @@ variable "guardrail_policies" {
   default     = ["arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess"]
 }
 
-variable "chatbot_iam_permissions" {
-  description = "List of IAM permissions for ChatBot role"
+variable "chatbot_policies" {
+  description = "List of IAM permissions for the policy to attach to the ChatBot role"
   type        = list(string)
   default = [
     "cloudwatch:Describe*",
@@ -136,7 +136,8 @@ variable "chatbot_iam_permissions" {
     "logs:TestMetricFilter",
     "logs:FilterLogEvents",
     "sns:Get*",
-    "sns:List*"
+    "sns:List*",
+    "ecs:DescribeTasks"
   ]
 }
 

--- a/terraform/monitoring/variables.tfvars.example
+++ b/terraform/monitoring/variables.tfvars.example
@@ -42,5 +42,6 @@ chatbot_iam_permissions       = [
   "logs:TestMetricFilter",
   "logs:FilterLogEvents",
   "sns:Get*",
-  "sns:List*"
+  "sns:List*",
+  "ecs:DescribeTasks"
 ]


### PR DESCRIPTION
- Move timeout logic to an entrypoint shell script that wraps the python process instead of implementing it directly in python; inspired by [medium article](https://medium.com/@rolanditaru/how-to-set-a-time-limit-on-your-aws-ecs-tasks-408838082fa5)

- Enhance logical separation of monitoring resources to separate task level failures (handled by an event bridge rule) and container level failures (covered by cloudwatch alarms)

     - For task level failures, i.e., ECS task state changes such as failure to start and spot interruption, match specific `stopCode` (see [Task API](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Task.html)) using [AWS resource events rule](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html), which has the failure SNS topic as the target

    - For container level failures, i.e., python process exits with non-zero code, use [CloudWatch alarm](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudwatch-alarm.html) with the failure SNS topic as `action`.
     